### PR TITLE
fix: 文件转移记录中蓝光原盘问题

### DIFF
--- a/app/filetransfer.py
+++ b/app/filetransfer.py
@@ -790,7 +790,7 @@ class FileTransfer:
                     in_from=in_from,
                     rmt_mode=rmt_mode,
                     in_path=reg_path,
-                    out_path=new_file if not bluray_disk_dir else None,
+                    out_path=new_file if not bluray_disk_dir else ret_dir_path,
                     dest=dist_path,
                     media_info=media)
                 # 未识别手动识别或历史记录重新识别的批处理模式


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20685540/218493335-99817f98-c266-4a7e-b296-a7a013b7f46c.png)
如上图，之前这里框住的部分是空，导致对于蓝光原盘的 TRANSFER_HISTORY 表实际是丢数据的。